### PR TITLE
Add support for alternate error handling strategy

### DIFF
--- a/internal/generate/kit/endpoint/endpointgen/gen.go
+++ b/internal/generate/kit/endpoint/endpointgen/gen.go
@@ -37,6 +37,9 @@ type Marker struct {
 
 	// WithOpenCensus enables generating a TraceEndpoint middleware.
 	WithOpenCensus bool `marker:"withOpenCensus,optional"`
+
+	// ErrorStrategy decides whether returned errors are checked for being endpoint or service errors.
+	ErrorStrategy string `marker:"errorStrategy,optional"`
 }
 
 // Generator generates a Go kit Endpoint for a service.

--- a/internal/generate/kit/endpoint/testdata/generator/multiple_services/endpoint/zz_generated.endpoint.go
+++ b/internal/generate/kit/endpoint/testdata/generator/multiple_services/endpoint/zz_generated.endpoint.go
@@ -18,9 +18,14 @@ import (
 	"sagikazarmark.dev/mga/internal/generate/kit/endpoint/testdata/generator/multiple_services"
 )
 
-// endpointError identifies an error that should be returned as an error endpoint.
+// endpointError identifies an error that should be returned as an endpoint error.
 type endpointError interface {
 	EndpointError() bool
+}
+
+// serviceError identifies an error that should be returned as a service error.
+type serviceError interface {
+	ServiceError() bool
 }
 
 // Endpoints collects all of the endpoints that compose the underlying service. It's

--- a/internal/generate/kit/endpoint/testdata/generator/service_error/endpoint/zz_generated.endpoint.go
+++ b/internal/generate/kit/endpoint/testdata/generator/service_error/endpoint/zz_generated.endpoint.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	kitoc "github.com/go-kit/kit/tracing/opencensus"
 	kitxendpoint "github.com/sagikazarmark/kitx/endpoint"
-	"sagikazarmark.dev/mga/internal/generate/kit/endpoint/testdata/generator/custom_module"
+	"sagikazarmark.dev/mga/internal/generate/kit/endpoint/testdata/generator/service_error"
 )
 
 // endpointError identifies an error that should be returned as an endpoint error.
@@ -37,15 +37,15 @@ type Endpoints struct {
 
 // MakeEndpoints returns a(n) Endpoints struct where each endpoint invokes
 // the corresponding method on the provided service.
-func MakeEndpoints(service custom_module.Service, middleware ...endpoint.Middleware) Endpoints {
+func MakeEndpoints(service service_error.Service, middleware ...endpoint.Middleware) Endpoints {
 	mw := kitxendpoint.Combine(middleware...)
 
-	return Endpoints{CreateTodo: kitxendpoint.OperationNameMiddleware("path.to.custom_module.CreateTodo")(mw(MakeCreateTodoEndpoint(service)))}
+	return Endpoints{CreateTodo: kitxendpoint.OperationNameMiddleware("service_error.CreateTodo")(mw(MakeCreateTodoEndpoint(service)))}
 }
 
 // TraceEndpoints returns a(n) Endpoints struct where each endpoint is wrapped with a tracing middleware.
 func TraceEndpoints(endpoints Endpoints) Endpoints {
-	return Endpoints{CreateTodo: kitoc.TraceEndpoint("path.to.custom_module.CreateTodo")(endpoints.CreateTodo)}
+	return Endpoints{CreateTodo: kitoc.TraceEndpoint("service_error.CreateTodo")(endpoints.CreateTodo)}
 }
 
 // CreateTodoRequest is a request struct for CreateTodo endpoint.
@@ -64,24 +64,24 @@ func (r CreateTodoResponse) Failed() error {
 }
 
 // MakeCreateTodoEndpoint returns an endpoint for the matching method of the underlying service.
-func MakeCreateTodoEndpoint(service custom_module.Service) endpoint.Endpoint {
+func MakeCreateTodoEndpoint(service service_error.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(CreateTodoRequest)
 
 		id, err := service.CreateTodo(ctx, req.Text)
 
 		if err != nil {
-			if endpointErr := endpointError(nil); errors.As(err, &endpointErr) && endpointErr.EndpointError() {
+			if serviceErr := serviceError(nil); errors.As(err, &serviceErr) && serviceErr.ServiceError() {
 				return CreateTodoResponse{
 					Err: err,
 					Id:  id,
-				}, err
+				}, nil
 			}
 
 			return CreateTodoResponse{
 				Err: err,
 				Id:  id,
-			}, nil
+			}, err
 		}
 
 		return CreateTodoResponse{Id: id}, nil

--- a/internal/generate/kit/endpoint/testdata/generator/service_error/service.go
+++ b/internal/generate/kit/endpoint/testdata/generator/service_error/service.go
@@ -1,0 +1,9 @@
+package service_error
+
+import (
+	"context"
+)
+
+type Service interface {
+	CreateTodo(ctx context.Context, text string) (id string, err error)
+}

--- a/internal/generate/kit/endpoint/testdata/generator/service_with_struct/endpoint/zz_generated.endpoint.go
+++ b/internal/generate/kit/endpoint/testdata/generator/service_with_struct/endpoint/zz_generated.endpoint.go
@@ -18,9 +18,14 @@ import (
 	"sagikazarmark.dev/mga/internal/generate/kit/endpoint/testdata/generator/service_with_struct"
 )
 
-// endpointError identifies an error that should be returned as an error endpoint.
+// endpointError identifies an error that should be returned as an endpoint error.
 type endpointError interface {
 	EndpointError() bool
+}
+
+// serviceError identifies an error that should be returned as a service error.
+type serviceError interface {
+	ServiceError() bool
 }
 
 // Endpoints collects all of the endpoints that compose the underlying service. It's

--- a/internal/generate/kit/endpoint/testdata/generator/simple_service/endpoint/zz_generated.endpoint.go
+++ b/internal/generate/kit/endpoint/testdata/generator/simple_service/endpoint/zz_generated.endpoint.go
@@ -18,9 +18,14 @@ import (
 	"sagikazarmark.dev/mga/internal/generate/kit/endpoint/testdata/generator/simple_service"
 )
 
-// endpointError identifies an error that should be returned as an error endpoint.
+// endpointError identifies an error that should be returned as an endpoint error.
 type endpointError interface {
 	EndpointError() bool
+}
+
+// serviceError identifies an error that should be returned as a service error.
+type serviceError interface {
+	ServiceError() bool
 }
 
 // Endpoints collects all of the endpoints that compose the underlying service. It's

--- a/internal/generate/kit/endpoint/testdata/generator/todo/endpoint/zz_generated.endpoint.go
+++ b/internal/generate/kit/endpoint/testdata/generator/todo/endpoint/zz_generated.endpoint.go
@@ -18,9 +18,14 @@ import (
 	"sagikazarmark.dev/mga/internal/generate/kit/endpoint/testdata/generator/todo"
 )
 
-// endpointError identifies an error that should be returned as an error endpoint.
+// endpointError identifies an error that should be returned as an endpoint error.
 type endpointError interface {
 	EndpointError() bool
+}
+
+// serviceError identifies an error that should be returned as a service error.
+type serviceError interface {
+	ServiceError() bool
 }
 
 // Endpoints collects all of the endpoints that compose the underlying service. It's

--- a/internal/generate/kit/endpoint/testdata/generator/unnamed_param/endpoint/zz_generated.endpoint.go
+++ b/internal/generate/kit/endpoint/testdata/generator/unnamed_param/endpoint/zz_generated.endpoint.go
@@ -18,9 +18,14 @@ import (
 	"sagikazarmark.dev/mga/internal/generate/kit/endpoint/testdata/generator/unnamed_param"
 )
 
-// endpointError identifies an error that should be returned as an error endpoint.
+// endpointError identifies an error that should be returned as an endpoint error.
 type endpointError interface {
 	EndpointError() bool
+}
+
+// serviceError identifies an error that should be returned as a service error.
+type serviceError interface {
+	ServiceError() bool
 }
 
 // Endpoints collects all of the endpoints that compose the underlying service. It's


### PR DESCRIPTION
Allow changing the error handling strategy in the generated endpoint:

- default: check if errors are explicitly marked as endpoint errors (and return them accordingly)
- service: check if errors are explicitly marked as service (business) errors (and return them accordingly)