### PR TITLE
fix(mock): corrected unnamed parameter, variadic parameter and function parameter generation

### DIFF
--- a/internal/generate/testify/mock/generator.go
+++ b/internal/generate/testify/mock/generator.go
@@ -69,8 +69,12 @@ func generateMock(code *jen.File, iface Interface) {
 		method := iface.Type.Method(i)
 
 		sig := method.Type().(*types.Signature)
+		isVariadicFunction := sig.Variadic()
 
 		const recv = "_m"
+		const varParamName = "varParam"
+		const varParamsName = "varParams"
+		const varIndexName = "varIndex"
 		const unnamedParameterPrefix = "_parameter_"
 		const unnamedResultPrefix = "_result_"
 
@@ -89,8 +93,19 @@ func generateMock(code *jen.File, iface Interface) {
 						paramName = fmt.Sprintf("%s%d", unnamedParameterPrefix, i)
 					}
 
-					jenutils.Import(code, param.Type())
-					jenutils.Type(group.Id(paramName), param.Type())
+					paramNameStatement := group.Id(paramName)
+					paramType := param.Type()
+					if isVariadicFunction &&
+						i == params.Len()-1 {
+						// Note: variadic type is received as []Type, but should
+						// be generated as ...Type function parameter.
+						paramNameStatement = paramNameStatement.Op("...")
+						sliceType := paramType.(*types.Slice)
+						paramType = sliceType.Elem()
+					}
+
+					jenutils.Import(code, paramType)
+					jenutils.Type(paramNameStatement, paramType)
 				}
 			}).
 			ParamsFunc(func(group *jen.Group) {
@@ -114,24 +129,70 @@ func generateMock(code *jen.File, iface Interface) {
 				var assertParams []jen.Code
 				var callParams []jen.Code
 
+				if isVariadicFunction {
+					paramName := params.At(params.Len() - 1).Name()
+					if paramName == "" {
+						paramName = fmt.Sprintf("%s%d", unnamedParameterPrefix, params.Len()-1)
+					}
+
+					group.Id(varParamsName).Op(":=").Make(
+						jen.List(
+							jen.Index().Add(jen.Interface()),
+							jen.Op(fmt.Sprintf("%d+len(%s)", params.Len()-1, paramName)),
+						),
+					)
+				}
+
 				for i := 0; i < params.Len(); i++ {
 					param := params.At(i)
+
 					paramName := param.Name()
 					if paramName == "" {
 						paramName = fmt.Sprintf("%s%d", unnamedParameterPrefix, i)
 					}
 
-					assertParams = append(assertParams, jenutils.Type(&jen.Statement{}, param.Type()))
-					callParams = append(callParams, jen.Id(paramName))
+					paramNameStatement := jen.Id(paramName)
+					paramType := param.Type()
+					paramTypeStatement := &jen.Statement{}
+					if isVariadicFunction &&
+						i == params.Len()-1 {
+						// Note: variadic type is received as []Type, but should
+						// be generated as ...Type function parameter and value... argument.
+						paramNameStatement = paramNameStatement.Op("...")
+						paramTypeStatement = paramTypeStatement.Op("...")
+						sliceType := paramType.(*types.Slice)
+						paramType = sliceType.Elem()
+					}
+
+					assertParams = append(assertParams, jenutils.Type(paramTypeStatement, paramType))
+					callParams = append(callParams, paramNameStatement)
+
+					if isVariadicFunction {
+						if i < params.Len()-1 {
+							group.Id(varParamsName).Index(jen.Op(fmt.Sprintf("%d", i))).Op("=").Id(paramName)
+						} else {
+							group.For(jen.List(jen.Id(varIndexName), jen.Id(varParamName))).Op(":=").Range().Id(paramName).Block(
+								jen.Id(varParamsName).Index(jen.Op(fmt.Sprintf("%d+%s", i, varIndexName))).Op("=").Id(varParamName),
+							)
+						}
+					}
+				}
+
+				calledParams := callParams
+				if isVariadicFunction {
+					group.Line()
+					calledParams = []jen.Code{
+						jen.Id(varParamsName).Op("..."),
+					}
 				}
 
 				if results.Len() == 0 {
-					group.Id(recv).Dot("Called").Call(callParams...)
+					group.Id(recv).Dot("Called").Call(calledParams...)
 
 					return
 				}
 
-				group.Id("ret").Op(":=").Id(recv).Dot("Called").Call(callParams...)
+				group.Id("ret").Op(":=").Id(recv).Dot("Called").Call(calledParams...)
 				group.Line()
 
 				var returns []jen.Code

--- a/internal/generate/testify/mock/generator.go
+++ b/internal/generate/testify/mock/generator.go
@@ -71,6 +71,8 @@ func generateMock(code *jen.File, iface Interface) {
 		sig := method.Type().(*types.Signature)
 
 		const recv = "_m"
+		const unnamedParameterPrefix = "_parameter_"
+		const unnamedResultPrefix = "_result_"
 
 		code.Commentf("%s provides a mock function.", method.Name())
 		code.Func().
@@ -82,8 +84,13 @@ func generateMock(code *jen.File, iface Interface) {
 				for i := 0; i < params.Len(); i++ {
 					param := params.At(i)
 
+					paramName := param.Name()
+					if paramName == "" {
+						paramName = fmt.Sprintf("%s%d", unnamedParameterPrefix, i)
+					}
+
 					jenutils.Import(code, param.Type())
-					jenutils.Type(group.Id(param.Name()), param.Type())
+					jenutils.Type(group.Id(paramName), param.Type())
 				}
 			}).
 			ParamsFunc(func(group *jen.Group) {
@@ -91,9 +98,13 @@ func generateMock(code *jen.File, iface Interface) {
 
 				for i := 0; i < results.Len(); i++ {
 					result := results.At(i)
+					resultName := result.Name()
+					if resultName == "" {
+						resultName = fmt.Sprintf("%s%d", unnamedResultPrefix, i)
+					}
 
 					jenutils.Import(code, result.Type())
-					jenutils.Type(group.Id(result.Name()), result.Type())
+					jenutils.Type(group.Id(resultName), result.Type())
 				}
 			}).
 			BlockFunc(func(group *jen.Group) {
@@ -105,9 +116,13 @@ func generateMock(code *jen.File, iface Interface) {
 
 				for i := 0; i < params.Len(); i++ {
 					param := params.At(i)
+					paramName := param.Name()
+					if paramName == "" {
+						paramName = fmt.Sprintf("%s%d", unnamedParameterPrefix, i)
+					}
 
 					assertParams = append(assertParams, jenutils.Type(&jen.Statement{}, param.Type()))
-					callParams = append(callParams, jen.Id(param.Name()))
+					callParams = append(callParams, jen.Id(paramName))
 				}
 
 				if results.Len() == 0 {

--- a/internal/generate/testify/mock/mockgen/test/service.go
+++ b/internal/generate/testify/mock/mockgen/test/service.go
@@ -61,3 +61,20 @@ type Service3 interface {
 	// nolint: lll
 	Refresh(ctx context.Context, refreshToken string, deviceID string, userName string, jwtToken *jwt.Token) (string, string, error)
 }
+
+//go:generate mga gen mockery --name Service4UnnamedParametersAndResults
+// +testify:mock
+// from https://github.com/sagikazarmark/mga/pull/42 #1.
+type Service4UnnamedParametersAndResults interface {
+	NamedParametersAndResults(isEnabled bool, count int, name string) (values []string, owner string, err error)
+
+	UnnamedParameter(bool) (values []string, owner string, err error)
+
+	UnnamedParameters(bool, int, string) (values []string, owner string, err error)
+
+	UnnamedParametersAndResults(bool, int, string) ([]string, string, error)
+
+	UnnamedResult(isEnabled bool, count int, name string) error
+
+	UnnamedResults(isEnabled bool, count int, name string) ([]string, string, error)
+}

--- a/internal/generate/testify/mock/mockgen/test/service.go
+++ b/internal/generate/testify/mock/mockgen/test/service.go
@@ -87,3 +87,17 @@ type Service5VariadicParameters interface {
 
 	Variadic(id string, count int, arguments ...interface{}) (err error)
 }
+
+//go:generate mga gen mockery --name Service6FunctionParameters
+// +testify:mock
+// from https://github.com/sagikazarmark/mga/pull/42 #3.
+type Service6FunctionParameters interface {
+	FunctionParameter(id string, predicate func(id oldtodo.ID, todo oldtodo.OldTodo) bool, count int) (err error)
+
+	FunctionParameters(
+		id string,
+		predicate func(id string, importedTodo oldtodo.OldTodo) bool,
+		operation func(count int, importedID oldtodo.ID),
+		count int,
+	) (err error)
+}

--- a/internal/generate/testify/mock/mockgen/test/service.go
+++ b/internal/generate/testify/mock/mockgen/test/service.go
@@ -78,3 +78,12 @@ type Service4UnnamedParametersAndResults interface {
 
 	UnnamedResults(isEnabled bool, count int, name string) ([]string, string, error)
 }
+
+//go:generate mga gen mockery --name Service5VariadicParameters
+// +testify:mock
+// from https://github.com/sagikazarmark/mga/pull/42 #2.
+type Service5VariadicParameters interface {
+	Regular(id string, count int, arguments []interface{}) (err error)
+
+	Variadic(id string, count int, arguments ...interface{}) (err error)
+}

--- a/pkg/jenutils/type.go
+++ b/pkg/jenutils/type.go
@@ -65,6 +65,30 @@ func Type(stmt *jen.Statement, t types.Type) jen.Code {
 	case *types.Pointer:
 		return Type(stmt.Op("*"), t.Elem())
 
+	case *types.Signature:
+		stmt := stmt.Func()
+
+		if t.Recv() != nil {
+			stmt.Params(Type(jen.Id(t.Recv().Name()), t.Recv().Type()))
+		}
+
+		if t.Params() != nil {
+			params := make([]jen.Code, t.Params().Len())
+			for paramIndex := 0; paramIndex < t.Params().Len(); paramIndex++ {
+				params[paramIndex] = Type(jen.Id(t.Params().At(paramIndex).Name()), t.Params().At(paramIndex).Type())
+			}
+			stmt.Params(params...)
+		}
+
+		if t.Results() != nil {
+			results := make([]jen.Code, t.Results().Len())
+			for resultIndex := 0; resultIndex < t.Results().Len(); resultIndex++ {
+				results[resultIndex] = Type(jen.Id(t.Results().At(resultIndex).Name()), t.Results().At(resultIndex).Type())
+			}
+			stmt.Params(results...)
+		}
+
+		return stmt
 	case *types.Struct:
 		var fields []jen.Code
 
@@ -113,6 +137,23 @@ func Import(file *jen.File, typ types.Type) {
 
 	case *types.Pointer:
 		Import(file, t.Elem())
+
+	case *types.Signature:
+		if t.Recv() != nil {
+			Import(file, t.Recv().Type())
+		}
+
+		if t.Params() != nil {
+			for paramIndex := 0; paramIndex < t.Params().Len(); paramIndex++ {
+				Import(file, t.Params().At(paramIndex).Type())
+			}
+		}
+
+		if t.Results() != nil {
+			for resultIndex := 0; resultIndex < t.Results().Len(); resultIndex++ {
+				Import(file, t.Results().At(resultIndex).Type())
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
# 1. Generating placeholder names for unnamed parameters and results

Previously when an interface with a function signature containing an unnamed parameter was mocked, the mock function definition logic generation resulted in invalid code resulting in compile error because of the inability to use the unnamed parameters in mock function calls.

The fix generates mock function signatures with a prefixed, indexed name for unnamed parameters such as `_parameter_0`, `_parameter_3` (the indexing is based on the parameter indices regardless of whether a parameter is named) and uses these names in the generated mock function calls.

Similar semantic is used to name unnamed results with a corresponding prefix (`_result_`) and index.

# 2. Generating variadic parameters

Previously when an interface with a function signature containing a variadic parameter was mocked, the mock function definition logic generation resulted in slices being generated in the mock function signature instead of variadic arguments which resulted in compiler error because the mock lacked the interface implementation logic for the variadic function signature.

The fix addresses this by altering the mock generation logic in case the function has a variadic signature, generating proper ellipsis function parameters and also adjusting function calls to use the variable ellipsis statement where a variadic argument is expected.

This also means that in case of variadic functions a temporary variadic parameter container needs to be generated to be passed to the `_m.Called(...)` function because the non-variadic (Type1, Type2), variadic ([]Type3) parameter passing to a different variadic ([]interface{}) parameter is not allowed.

# 3. Generating function pointer parameters and corresponding imports

Previously function pointers as function parameters were not supported because neither the import, nor the type generation logic supported signatures at the parameter level and thus the generation resulted in panic.

The fix adds `*types.Signature` handling at these generation steps to handle function pointer parameters like all other types, including receivers, parameters and results in a function pointer argument.