### PR TITLE
Add support for external test packages in mocks

### DIFF
--- a/internal/generate/testify/mock/mockgen/test/.gitignore
+++ b/internal/generate/testify/mock/mockgen/test/.gitignore
@@ -1,3 +1,4 @@
 mocks/
 zz_generated.mock.go
 zz_generated.mock_test.go
+zz_generated.mock_external_test.go

--- a/internal/generate/testify/mock/mockgen/test/service.go
+++ b/internal/generate/testify/mock/mockgen/test/service.go
@@ -101,3 +101,41 @@ type Service6FunctionParameters interface {
 		count int,
 	) (err error)
 }
+
+//go:generate mga gen mockery --name Service7
+// +testify:mock:external=true
+type Service7 interface {
+	// CreateTodo adds a new todo to the todo list.
+	CreateTodo(ctx context.Context, text string) (id string, err error)
+
+	// ListTodos returns the list of todos.
+	ListTodos(ctx context.Context) ([]Todo, error)
+
+	// MarkAsDone marks a todo as done.
+	MarkAsDone(ctx context.Context, id string) error
+
+	// TouchTodo records work on a todo.
+	TouchTodo(ctx context.Context, id string)
+
+	// ImportOldTodo imports a todo from the old format.
+	ImportOldTodo(ctx context.Context, oldTodo oldtodo.OldTodo) (id string, err error)
+}
+
+//go:generate mga gen mockery --name Service8
+// +testify:mock:external=true,testOnly=true
+type Service8 interface {
+	// CreateTodo adds a new todo to the todo list.
+	CreateTodo(ctx context.Context, text string) (id string, err error)
+
+	// ListTodos returns the list of todos.
+	ListTodos(ctx context.Context) ([]Todo, error)
+
+	// MarkAsDone marks a todo as done.
+	MarkAsDone(ctx context.Context, id string) error
+
+	// TouchTodo records work on a todo.
+	TouchTodo(ctx context.Context, id string)
+
+	// ImportOldTodo imports a todo from the old format.
+	ImportOldTodo(ctx context.Context, oldTodo oldtodo.OldTodo) (id string, err error)
+}


### PR DESCRIPTION
Tests are often in external packages (package name suffixed with _test).
While it is possible to import from test files in external packages,
one might not want to do that.

For example, build systems often don't support that:
https://github.com/thought-machine/please/issues/1184
