### PR TITLE
Support one-way channels in jenutils

### DIFF
--- a/pkg/jenutils/type.go
+++ b/pkg/jenutils/type.go
@@ -46,7 +46,15 @@ func Type(stmt *jen.Statement, t types.Type) jen.Code {
 		return Type(stmt.Index(), t.Elem())
 
 	case *types.Chan:
-		return Type(stmt.Chan(), t.Elem())
+		if t.Dir() == types.RecvOnly {
+			stmt = stmt.Op("<-")
+		}
+		stmt = stmt.Chan()
+		if t.Dir() == types.SendOnly {
+			stmt = stmt.Op("<-")
+		}
+
+		return Type(stmt, t.Elem())
 
 	case *types.Map:
 		return Type(stmt.Map(Type(&jen.Statement{}, t.Key())), t.Elem())


### PR DESCRIPTION
Currently channels of type, for instance, `<- chan int` or `chan <- int` will not be generated correctly- they will both be generated as `chan int`.  This commit changes that.